### PR TITLE
Accept raw hooks for providers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,10 @@ jobs:
           command: mv config/database{.circle,}.yml && bundle exec rake db:create db:migrate
 
       - run:
+          name: Update Chrome
+          command: bundle exec rake webdrivers:chromedriver:update
+
+      - run:
           name: Run tests
           command: bundle exec rake
 

--- a/Gemfile
+++ b/Gemfile
@@ -32,4 +32,11 @@ group :development, :test do
   gem 'pry-rails'
   gem 'rspec-rails'
   gem 'rubocop-rails'
+  gem 'webdrivers'
+end
+
+group :test do
+  gem 'capybara'
+  gem 'selenium-webdriver'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,10 +56,21 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
     bcrypt (3.1.16)
     bindex (0.8.1)
     builder (3.2.4)
+    capybara (3.34.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
+    childprocess (3.0.0)
     choice (0.2.0)
     coderay (1.1.3)
     coffee-rails (5.0.0)
@@ -70,6 +81,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.7)
+    crack (0.4.4)
     crass (1.0.6)
     decent_exposure (3.0.2)
       activesupport (>= 4.0)
@@ -100,6 +112,7 @@ GEM
       haml (>= 4.0.6, < 6.0)
       html2haml (>= 1.0.1)
       railties (>= 5.1)
+    hashdiff (1.0.1)
     honeybadger (4.7.2)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
@@ -142,6 +155,7 @@ GEM
       method_source (~> 1.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
+    public_suffix (4.0.6)
     puma (5.0.4)
       nio4r (~> 2.0)
     rack (2.2.3)
@@ -230,6 +244,7 @@ GEM
     ruby-progressbar (1.10.1)
     ruby_parser (3.15.0)
       sexp_processor (~> 4.9)
+    rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -240,6 +255,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     sexp_processor (4.15.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -264,15 +282,26 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (4.4.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
+    webmock (3.10.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.4.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  capybara
   coffee-rails
   decent_exposure
   devise
@@ -291,8 +320,11 @@ DEPENDENCIES
   rspec-rails
   rubocop-rails
   sass-rails
+  selenium-webdriver
   uglifier
   web-console
+  webdrivers
+  webmock
 
 RUBY VERSION
    ruby 2.7.1p83

--- a/app/controllers/admin/providers_controller.rb
+++ b/app/controllers/admin/providers_controller.rb
@@ -1,0 +1,5 @@
+module Admin
+  class ProvidersController < AdminController
+    expose(:providers) { Provider.order(:created_at).limit(10) }
+  end
+end

--- a/app/controllers/admin/raw_hooks_controller.rb
+++ b/app/controllers/admin/raw_hooks_controller.rb
@@ -1,0 +1,5 @@
+module Admin
+  class RawHooksController < AdminController
+    expose(:raw_hooks) { RawHook.order(:created_at).limit(10) }
+  end
+end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,2 @@
+class AdminController < ApplicationController
+end

--- a/app/controllers/raw_hooks_controller.rb
+++ b/app/controllers/raw_hooks_controller.rb
@@ -1,0 +1,14 @@
+class RawHooksController < ApplicationController
+  expose(:raw_hook) do
+    attrs = HookRequest.to_attrs(request, params)
+    RawHook.new(attrs)
+  end
+
+  def create
+    if raw_hook.save
+      head :created
+    else
+      head :unprocessable_entity
+    end
+  end
+end

--- a/app/models/hook_request.rb
+++ b/app/models/hook_request.rb
@@ -1,0 +1,42 @@
+class HookRequest
+  def self.to_attrs(request, params)
+    new(request, params).to_attrs
+  end
+
+  attr_reader :request, :params
+
+  def initialize(request, params)
+    @request = request
+    @params = params
+  end
+
+  def to_attrs
+    {
+      body: request_body,
+      headers: loud_headers,
+      params: unsafe_params
+    }
+  end
+
+  private
+
+  def request_body
+    @request_body ||= request.body.read
+  end
+
+  def headers_hash
+    @headers_hash ||= request.headers.to_h
+  end
+
+  def loud_header_keys
+    headers_hash.keys.select { |key| key == key.upcase && !key.starts_with?('ROUTES') }
+  end
+
+  def loud_headers
+    headers_hash.slice(*loud_header_keys)
+  end
+
+  def unsafe_params
+    params.to_unsafe_hash
+  end
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -1,0 +1,2 @@
+class Provider < ApplicationRecord
+end

--- a/app/models/raw_hook.rb
+++ b/app/models/raw_hook.rb
@@ -1,0 +1,2 @@
+class RawHook < ApplicationRecord
+end

--- a/app/views/admin/providers/index.html.haml
+++ b/app/views/admin/providers/index.html.haml
@@ -1,0 +1,5 @@
+%h1 Providers
+
+%ul
+  - providers.each do |provider|
+    %li= provider.id

--- a/app/views/admin/raw_hooks/index.html.haml
+++ b/app/views/admin/raw_hooks/index.html.haml
@@ -1,0 +1,5 @@
+%h1 Raw Hooks
+
+%ul
+  - raw_hooks.each do |raw_hook|
+    %li= raw_hook.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,9 @@ Rails.application.routes.draw do
     post '/', to: 'raw_hooks#create'
   end
 
+  namespace 'admin' do
+    resources :raw_hooks, only: %i[index show]
+  end
+
   get :ping, to: 'ping#show'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   end
 
   constraints subdomain: 'hooks' do
-    post '/v1/:project_token', to: 'hooks#create'
+    post '/', to: 'raw_hooks#create'
   end
 
   get :ping, to: 'ping#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   end
 
   namespace 'admin' do
+    resources :providers, only: %i[index show]
     resources :raw_hooks, only: %i[index show]
   end
 

--- a/db/migrate/20201124211805_create_raw_hooks.rb
+++ b/db/migrate/20201124211805_create_raw_hooks.rb
@@ -1,0 +1,11 @@
+class CreateRawHooks < ActiveRecord::Migration[6.0]
+  def change
+    create_table :raw_hooks do |t|
+      t.jsonb :headers
+      t.jsonb :params
+      t.text :body
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201127192406_create_providers.rb
+++ b/db/migrate/20201127192406_create_providers.rb
@@ -1,0 +1,10 @@
+class CreateProviders < ActiveRecord::Migration[6.0]
+  def change
+    create_table :providers do |t|
+      t.string :name
+      t.string :parser
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/factories/provider.rb
+++ b/spec/factories/provider.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :provider do
+    name 'GitHub'
+    parser 'GitHubParser'
+  end
+end

--- a/spec/factories/raw_hook.rb
+++ b/spec/factories/raw_hook.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :raw_hook do
+    body 'Something awesome'
+    headers { { omg: 'lol' } }
+    params { { foo: 'bar' } }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,58 +1,30 @@
-# This file is copied to spec/ when you run 'rails generate rspec:install'
+require 'spec_helper'
+
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 message = 'The Rails environment is running in production mode!'
 abort(message) if Rails.env.production?
-require 'spec_helper'
 require 'rspec/rails'
+require 'webmock/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
-# Requires supporting ruby files with custom matchers and macros, etc, in
-# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
-# run as spec files by default. This means that files in spec/support that end
-# in _spec.rb will both be required and run as specs, causing the specs to be
-# run twice. It is recommended that you do not name files matching this glob to
-# end with _spec.rb. You can configure this pattern with the --pattern
-# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
-#
-# The following line is provided for convenience purposes. It has the downside
-# of increasing the boot-up time by auto-requiring all files in the support
-# directory. Alternatively, in the individual `*_spec.rb` files, manually
-# require only the support files necessary.
-#
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
-
-# Checks for pending migration and applies them before tests are run.
-# If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
+  config.filter_rails_from_backtrace!
+  config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = true
 
-  # RSpec Rails can automatically mix in different behaviours to your tests
-  # based on their file location, for example enabling you to call `get` and
-  # `post` in specs under `spec/controllers`.
-  #
-  # You can disable this behaviour by removing the line below, and instead
-  # explicitly tag your specs with their type, e.g.:
-  #
-  #     RSpec.describe UsersController, :type => :controller do
-  #       # ...
-  #     end
-  #
-  # The different available types are documented in the features, such as in
-  # https://relishapp.com/rspec/rspec-rails/docs
-  config.infer_spec_type_from_file_location!
+  config.before(:each, type: :system) do
+    config.include Warden::Test::Helpers
+    Capybara.server = :puma, { Silent: true }
+    driven_by :selenium_chrome_headless
+  end
 
-  # Filter lines from Rails gems in backtraces.
-  config.filter_rails_from_backtrace!
-  # arbitrary gems may also be filtered via:
-  # config.filter_gems_from_backtrace("gem name")
+  config.after(:each, type: :system) do
+    Warden.test_reset!
+  end
 end
+
+WebMock.disable_net_connect!(allow_localhost: true)

--- a/spec/requests/hooks/circle_spec.rb
+++ b/spec/requests/hooks/circle_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Circle CI Hooks', subdomain: 'hooks' do
+xdescribe 'Circle CI Hooks', subdomain: 'hooks' do
   let(:service) { FactoryBot.create :circle_service }
 
   let(:project) { service.projects.create name: 'jonallured/cybertail-rails' }

--- a/spec/requests/hooks/github_hooks_spec.rb
+++ b/spec/requests/hooks/github_hooks_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'GitHub hooks', subdomain: 'hooks' do
+xdescribe 'GitHub hooks', subdomain: 'hooks' do
   let(:service) { FactoryBot.create :github_service }
 
   context 'unknown event' do

--- a/spec/requests/hooks/heroku_spec.rb
+++ b/spec/requests/hooks/heroku_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Heroku hooks', subdomain: 'hooks' do
+xdescribe 'Heroku hooks', subdomain: 'hooks' do
   it 'something' do
     service = FactoryBot.create :heroku_service
     project = service.projects.create name: 'cybertail'

--- a/spec/requests/hooks/honeybadger_spec.rb
+++ b/spec/requests/hooks/honeybadger_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Honeybadger hooks', subdomain: 'hooks' do
+xdescribe 'Honeybadger hooks', subdomain: 'hooks' do
   it 'something' do
     service = FactoryBot.create :honeybadger_service
     project = service.projects.create name: 'Cybertail'

--- a/spec/requests/hooks/raw_hook_spec.rb
+++ b/spec/requests/hooks/raw_hook_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+describe 'Raw hook', subdomain: 'hooks' do
+  let(:default_header_keys) do
+    %w[
+      CONTENT_LENGTH
+      CONTENT_TYPE
+      HTTPS
+      HTTP_ACCEPT
+      HTTP_COOKIE
+      HTTP_HOST
+      ORIGINAL_FULLPATH
+      ORIGINAL_SCRIPT_NAME
+      PATH_INFO
+      QUERY_STRING
+      REMOTE_ADDR
+      REQUEST_METHOD
+      REQUEST_URI
+      SCRIPT_NAME
+      SERVER_NAME
+      SERVER_PORT
+    ]
+  end
+
+  let(:default_params) do
+    {
+      'action' => 'create',
+      'controller' => 'raw_hooks',
+      'subdomain' => 'hooks'
+    }
+  end
+
+  context 'with empty params and headers' do
+    let(:headers) { {} }
+    let(:params) { {} }
+
+    it 'stores default params and headers' do
+      post '/', params: params, headers: headers
+
+      expect(response.status).to be 201
+      expect(RawHook.count).to eq 1
+
+      raw_hook = RawHook.first
+      expect(default_header_keys).to match_array(raw_hook.headers.keys)
+      expect(raw_hook.params).to eq default_params
+    end
+  end
+
+  context 'with extra params and headers' do
+    let(:headers) { { 'X-STRING-HEADER' => 'token', 'X-INTEGER-HEADER' => 7 } }
+    let(:params) { { string_param: 'password', integer_param: 11 } }
+
+    it 'stores those too' do
+      post '/', params: params, headers: headers
+
+      expect(response.status).to be 201
+      expect(RawHook.count).to eq 1
+
+      raw_hook = RawHook.first
+
+      expect(raw_hook.headers['HTTP_X_STRING_HEADER']).to eq 'token'
+      expect(raw_hook.headers['HTTP_X_INTEGER_HEADER']).to eq 7
+
+      expect(raw_hook.params['string_param']).to eq 'password'
+      expect(raw_hook.params['integer_param']).to eq '11'
+    end
+  end
+end

--- a/spec/requests/hooks/travis_spec.rb
+++ b/spec/requests/hooks/travis_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Travis hooks', subdomain: 'hooks' do
+xdescribe 'Travis hooks', subdomain: 'hooks' do
   it 'something' do
     service = FactoryBot.create :travis_service
     project = service.projects.create name: 'jonallured/cybertail-rails'

--- a/spec/system/admin/providers_list_spec.rb
+++ b/spec/system/admin/providers_list_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe 'Providers list page' do
+  before do
+    FactoryBot.create_list(:provider, provider_count)
+  end
+
+  context 'with no providers' do
+    let(:provider_count) { 0 }
+
+    it 'draws an empty list' do
+      visit '/admin/providers'
+      expect(page).to have_content 'Providers'
+      expect(page).to_not have_css('li')
+    end
+  end
+
+  context 'with a few providers' do
+    let(:provider_count) { 3 }
+
+    it 'shows those providers' do
+      visit '/admin/providers'
+      expect(page).to have_css('li', count: 3)
+    end
+  end
+
+  context 'with a bunch of providers' do
+    let(:provider_count) { 30 }
+
+    it 'shows the first 10 providers' do
+      visit '/admin/providers'
+      expect(page).to have_css('li', count: 10)
+    end
+  end
+end

--- a/spec/system/admin/raw_hooks_list_spec.rb
+++ b/spec/system/admin/raw_hooks_list_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe 'Raw Hooks list page' do
+  before do
+    FactoryBot.create_list(:raw_hook, raw_hook_count)
+  end
+
+  context 'with no hooks' do
+    let(:raw_hook_count) { 0 }
+
+    it 'draws an empty list' do
+      visit '/admin/raw_hooks'
+      expect(page).to have_content 'Raw Hooks'
+      expect(page).to_not have_css('li')
+    end
+  end
+
+  context 'with a few hooks' do
+    let(:raw_hook_count) { 3 }
+
+    it 'shows those hooks' do
+      visit '/admin/raw_hooks'
+      expect(page).to have_css('li', count: 3)
+    end
+  end
+
+  context 'with a bunch of hooks' do
+    let(:raw_hook_count) { 30 }
+
+    it 'shows the first 10 hooks' do
+      visit '/admin/raw_hooks'
+      expect(page).to have_css('li', count: 10)
+    end
+  end
+end


### PR DESCRIPTION
This PR reverses some changes where I was accepting AND parsing hooks in one shot. What I'm going for here is an approach that's more about simply accepting hooks and then deferring the parsing to a later stage. This is more in line with the typical ETL pipeline and should resolve some exceptions I've been having.

It also introduces an admin interface - what I'm hoping to achieve before too long is a real-time view I can load up that will show me all the hooks as they come in and then I can click into things and see how they've been parsed, etc.

Note: I have disabled a set of tests that were focused on the parsing of hooks into something that is suitable for users. My plan is to move these tests to another part of the pipeline. They should prove valuable when it comes time to work on parsing RawHook records into ParsedHook records.