### PR TITLE
Add basic raw hook detail page

### DIFF
--- a/app/controllers/admin/raw_hooks_controller.rb
+++ b/app/controllers/admin/raw_hooks_controller.rb
@@ -1,5 +1,6 @@
 module Admin
   class RawHooksController < AdminController
-    expose(:raw_hooks) { RawHook.order(:created_at).limit(10) }
+    expose(:raw_hooks) { RawHook.order(created_at: :desc).limit(20) }
+    expose(:raw_hook) { RawHook.find(params[:id]) }
   end
 end

--- a/app/views/admin/raw_hooks/index.html.haml
+++ b/app/views/admin/raw_hooks/index.html.haml
@@ -2,4 +2,5 @@
 
 %ul
   - raw_hooks.each do |raw_hook|
-    %li= raw_hook.id
+    %li
+      %a{href: admin_raw_hook_path(raw_hook)} #{raw_hook.id} - #{raw_hook.body.first(100)}

--- a/app/views/admin/raw_hooks/show.html.haml
+++ b/app/views/admin/raw_hooks/show.html.haml
@@ -1,0 +1,11 @@
+%h1 Raw Hook #{raw_hook.id}
+
+%h2 Body
+%code
+  %pre= JSON.pretty_generate(JSON.parse(raw_hook.body.as_json))
+%h2 Headers
+%code
+  %pre= JSON.pretty_generate(raw_hook.headers)
+%h2 Params
+%code
+  %pre= JSON.pretty_generate(raw_hook.params)

--- a/bin/sync_data
+++ b/bin/sync_data
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ex
+
+heroku pg:reset DATABASE_URL --confirm cybertail-staging --remote staging
+staging_url=$(heroku config:get DATABASE_URL --remote staging)
+heroku pg:pull DATABASE_URL $staging_url --remote production
+dropdb cybertail_development
+heroku pg:pull DATABASE_URL cybertail_development --remote staging
+bundle exec rake db:environment:set RAILS_ENV=development

--- a/spec/system/admin/raw_hooks_list_spec.rb
+++ b/spec/system/admin/raw_hooks_list_spec.rb
@@ -29,7 +29,7 @@ describe 'Raw Hooks list page' do
 
     it 'shows the first 10 hooks' do
       visit '/admin/raw_hooks'
-      expect(page).to have_css('li', count: 10)
+      expect(page).to have_css('li', count: 20)
     end
   end
 end


### PR DESCRIPTION
This PR adds a nice basic detail page for raw hooks so that I can examine them more closely. I also copied over my typical task to sync data along the production/staging/local environments so I can play with things locally.